### PR TITLE
Fixes Repeated Usernames Bug

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -63,10 +63,7 @@ pub async fn handle_connection(username: String, socket: WebSocket, conn_tx: Con
     tokio::task::spawn(async move {
         loop {
             tokio::select! {
-                _ = og_token.cancelled() => {
-                    let _ = ws_tx.close().await;
-                    break;
-                }
+                biased;
                 Some(message) = og_rx.recv() => {
                     let text = match serde_json::to_string(&message) {
                         Ok(t) => t,
@@ -80,6 +77,10 @@ pub async fn handle_connection(username: String, socket: WebSocket, conn_tx: Con
                         og_token.cancel();
                         break;
                     };
+                }
+                _ = og_token.cancelled() => {
+                    let _ = ws_tx.close().await;
+                    break;
                 }
             }
         }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,5 +1,8 @@
 use futures_util::{SinkExt, StreamExt};
-use tokio::sync::mpsc::{self, error::SendError};
+use tokio::sync::{
+    mpsc::{self, error::SendError},
+    oneshot,
+};
 
 use crate::game::message::Message as GameMessage;
 use tokio_util::sync::CancellationToken;
@@ -17,7 +20,8 @@ pub enum ConnectionUpdate {
 #[derive(Debug)]
 pub struct Connection {
     pub username: String,
-    token: CancellationToken,
+    accept_tx: Option<oneshot::Sender<bool>>,
+    close_token: CancellationToken,
     rx: mpsc::UnboundedReceiver<GameMessage>,
     tx: mpsc::UnboundedSender<GameMessage>,
 }
@@ -32,20 +36,35 @@ impl Connection {
     }
 
     pub fn close(&mut self) {
-        self.token.cancel();
+        self.close_token.cancel();
+    }
+
+    pub fn decline(&mut self) {
+        if let Some(tx) = self.accept_tx.take() {
+            let _ = tx.send(false);
+        }
+        self.close_token.cancel();
+    }
+
+    pub fn accept(&mut self) {
+        if let Some(tx) = self.accept_tx.take() {
+            let _ = tx.send(true);
+        }
     }
 }
 
 pub async fn handle_connection(username: String, socket: WebSocket, conn_tx: ConnTx) {
     let (im_tx, im_rx) = mpsc::unbounded_channel::<GameMessage>();
     let (og_tx, mut og_rx) = mpsc::unbounded_channel::<GameMessage>();
-    let token = CancellationToken::new();
+    let close_token = CancellationToken::new();
+    let (accept_tx, accept_rx) = oneshot::channel::<bool>();
 
     let og_tx_2 = og_tx.clone();
 
     let conn = Connection {
         username: username.clone(),
-        token: token.clone(),
+        accept_tx: Some(accept_tx),
+        close_token: close_token.clone(),
         rx: im_rx,
         tx: og_tx,
     };
@@ -59,7 +78,7 @@ pub async fn handle_connection(username: String, socket: WebSocket, conn_tx: Con
 
     let (mut ws_tx, mut ws_rx) = socket.split();
 
-    let og_token = token.clone();
+    let og_token = close_token.clone();
     tokio::task::spawn(async move {
         loop {
             tokio::select! {
@@ -87,7 +106,7 @@ pub async fn handle_connection(username: String, socket: WebSocket, conn_tx: Con
         // println!("Outgoing Messages loop cancelled");
     });
 
-    let im_token = token.child_token();
+    let im_token = close_token.child_token();
     loop {
         tokio::select! {
             Some(result) = ws_rx.next() => {
@@ -126,6 +145,8 @@ pub async fn handle_connection(username: String, socket: WebSocket, conn_tx: Con
     }
     // println!("Incoming Messages loop cancelled");
 
-    token.cancel();
-    let _ = conn_tx.send(ConnectionUpdate::Disconnected(username));
+    close_token.cancel();
+    if let Ok(true) = accept_rx.await {
+        let _ = conn_tx.send(ConnectionUpdate::Disconnected(username));
+    }
 }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -11,7 +11,8 @@ pub mod message;
 #[derive(Debug)]
 pub enum GameStatus {
     Playing,
-    GameOver,
+    GameWon(String),
+    Stalemate,
 }
 
 #[derive(Debug, Error)]
@@ -96,13 +97,17 @@ impl Game {
                     if let Err(_) = self.broadcast(Message::won(&self.board, winner)) {
                         return Err(GameError::ConnectionError);
                     }
-                    return Ok(GameStatus::GameOver);
+                    let w_username = match winner {
+                        Color::Red => self.red.username.clone(),
+                        Color::Blue => self.blue.username.clone(),
+                    };
+                    return Ok(GameStatus::GameWon(w_username));
                 }
                 BoardState::Stalemate => {
                     if let Err(_) = self.broadcast(Message::stalemate(&self.board)) {
                         return Err(GameError::ConnectionError);
                     }
-                    return Ok(GameStatus::GameOver);
+                    return Ok(GameStatus::Stalemate);
                 }
             },
             Err(play_err) => {

--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -1,8 +1,8 @@
-use std::{collections::HashMap, time::Duration};
+use std::collections::HashMap;
 
 use rand::random_bool;
 use thiserror::Error;
-use tokio::{sync::mpsc, time::sleep};
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -190,8 +190,12 @@ async fn gameplay(mut game: Game, mo: MatchOver, over_tx: MatchOverTx) {
         match game.play().await {
             Ok(status) => match status {
                 GameStatus::Playing => {}
-                GameStatus::GameOver => {
-                    println!("[Game {}] Game over", game.id());
+                GameStatus::GameWon(winner) => {
+                    println!("[Game {}] \"{}\" won", game.id(), winner);
+                    break;
+                }
+                GameStatus::Stalemate => {
+                    println!("[Game {}] Ended in stalemate", game.id());
                     break;
                 }
             },
@@ -201,7 +205,7 @@ async fn gameplay(mut game: Game, mo: MatchOver, over_tx: MatchOverTx) {
             }
         }
     }
-    sleep(Duration::from_secs(3)).await;
+    // sleep(Duration::from_secs(3)).await;
     let _ = over_tx.send(mo);
-    let _ = game.game_over();
+    game.game_over();
 }

--- a/src/lobby.rs
+++ b/src/lobby.rs
@@ -79,12 +79,14 @@ impl Lobby {
                 let username = conn.username.clone();
                 if self.connecting.contains_key(&username) || self.playing.contains_key(&username) {
                     let _ = conn.send(Message::RepeatUsername);
-                    conn.close();
-                    // MASSIVE BUG! USING REPEAT USERNAMES WILL TRIGGER DISCONNECTED BLOCK
-                    // BELOW. USERS CAN CAUSE OTHERS TO BE KICKED
+                    println!(
+                        "[Lobby] Player \"{}\" attempted to connect with repeat username",
+                        &username
+                    );
+                    conn.decline();
                     return Ok(());
                 }
-
+                conn.accept();
                 println!("[Lobby] Player \"{}\" connecting", &username);
                 self.connecting.insert(username, conn);
                 let mc = match self.matchmake() {

--- a/static/scripts/play.js
+++ b/static/scripts/play.js
@@ -95,10 +95,12 @@ window.onload = function (e) {
 
     socket.onclose = function (e) {
       console.log("Disconnected");
-      status_disconnected();
-      buttons_connect(false);
-      clear_chips(chips);
-      socket = null;
+      setTimeout(function () {
+        status_disconnected();
+        buttons_connect(false);
+        clear_chips(chips);
+        socket = null;
+      }, 5000);
     };
 
     socket.onerror = function (e) {


### PR DESCRIPTION
Targeting Issue #3 

- Fixes repeated usernames bug
- Fixes race condition where closing the game after announcing the winner can cause the winner message to not be sent out
- Prints out winner/stalemates in logs